### PR TITLE
Anpassung Glossar

### DIFF
--- a/Dokumentationen/requirements/Glossar.adoc
+++ b/Dokumentationen/requirements/Glossar.adoc
@@ -37,11 +37,11 @@ a|* Englisch für Vorlage/ Schablone
 a|* Anforderung eines Versuchsaufbaus mit Durchführung zur einer festgelegten Zeit
 |
 
-|Checkout
+|Warenkorb
 a|* Temporärer Sammelspeicher für bestellte Experimente pro Dozent
 * Bestellübersicht mit Datums- und Zeitauswahl
 a|* Bestellzusammenfassung
-* Warenkorb
+* Checkout
 
 |Buchungsschaltfläche
 a|* Schaltfläche, die dem Nutzer per Klick die Buchung eines Experiments ermöglicht
@@ -49,31 +49,23 @@ a|* Schaltfläche, die dem Nutzer per Klick die Buchung eines Experiments ermög
 a|* Warenkorbicon
 * Warenkorbsymbol 
 
+|Voreinstellungen 
+a| * Festlegung der Bestelldetails (ohne Anmeldedaten) vor Auswahl der Buchungen 
+a|
+
 |Bestelldetails
 a|* Bei Buchung eines konkreten Experimentes anzugebende Informationen
-* enthält: Anmeldedaten (siehe 1.3 Datenstrukturen)
+* enthält: Studiengang, Datum, Zeit, Kommentar, Anmeldedaten (siehe 1.3 Datenstrukturen)
 |
-
-|Buchungseinsicht
-a|* Übersichtliche Dokumentation zur Einsicht der Bestelldetails
-* Ergänzund zum Wochenplan
-|
-
-|Wochenplan
-a|* Übersicht aller Bestellungen und der Termine der Bereitstellung und Durchführung für die Folgewoche
-* Information für den Admin
-a|* Wochenübersicht
-* Buchungseinsicht 
-
 
 |Journal
 a|* Übersicht der eigenen Buchungen mit Anpassungsmöglichkeiten für Dozenten
+a|
 
 |Dozentenwoche
 a|* Darstellung aller für eine Woche durch einen bestimmten Dozenten gebuchten Experimente
 * "Wochenplan pro Dozent"
-* Information für den Dozenten (buchenden Nutzer)
-
+* Übersicht/Druckansicht für Admin
 |
 
 |Deadline 


### PR DESCRIPTION
Stand 28.12.2020

Ergänzung:
- Voreinstellung 
- Bestelldatails

Korrektur: 
- "Wochenplan" entfernt 
- Journal
- Dozentenwoche 

**Bitte den Branch nicht löschen nachdem gemerged wurde. Danke**

closes #50