### PR TITLE
Improve Checkout Usability

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :authorize_user!
+  before_action :set_order
 
   def after_sign_in_path_for(resource)
     "/"
@@ -13,5 +14,9 @@ class ApplicationController < ActionController::Base
     if authorize.disallow?
       redirect_to "/", alert: "Benötigte Rechte nicht vorhanden."
     end
+  end
+
+  def set_order
+    @order = session[:order]
   end
 end

--- a/src/app/controllers/checkouts_controller.rb
+++ b/src/app/controllers/checkouts_controller.rb
@@ -169,7 +169,8 @@ class CheckoutsController < ApplicationController
   #
   # @author Richard Böhme
   def set_order
-    @order = session[:order]
+    super
+
     unless @order
       redirect_to root_path
     end

--- a/src/app/views/checkouts/_sidebar.slim
+++ b/src/app/views/checkouts/_sidebar.slim
@@ -1,0 +1,17 @@
+.position-fixed style="top: 23%"
+  = link_to("zum Buchungsabschluss", checkout_path, class: "btn btn-secondary d-block #{@order.ordered_experiments.blank? ? "disabled" : ""}".rstrip)
+  = link_to("Buchung abbrechen", checkout_path, method: :delete, class: "btn btn-light mt-2", data: { confirm: "Wollen Sie die Buchung wirklich abbrechen?" })
+  button data-toggle="modal" data-target="#dummy-experiment-modal" class="btn btn-secondary d-block mt-2" manuell Experiment hinzufügen
+#dummy-experiment-modal.modal.fade tabindex="-1"
+  .modal-dialog
+    .modal-content
+      = simple_form_for(DummyExperiment.new, url: add_experiment_checkout_path, method: :patch) do |f|
+        .modal-header
+          h5.modal-title Manuell Experiment hinzufügen
+          button.close data-dismiss="modal" type="button"
+            span  &times;
+        .modal-body
+          = f.input :name, label: "Name"
+        .modal-footer
+          button.btn.btn-secondary data-dismiss="modal" type="button" Abbrechen
+          = f.submit "Experiment hinzufügen", class: "btn btn-primary"

--- a/src/app/views/layouts/_header.slim
+++ b/src/app/views/layouts/_header.slim
@@ -11,7 +11,7 @@ header
         - Category.sorted.each do |category|
           li.nav-item
             b = link_to category.name, category, class: "nav-link"
-      - if !session.key?(:order) && current_user.role.to_sym == :lecturer
+      - if @order.blank? && current_user.role.to_sym == :lecturer
         = link_to "Buchung starten", new_checkout_path, class: "btn btn-secondary mr-4 btn-sm"
       = form_tag(experiments_path, method: :get, class:"form form-inline my-3 my-lg-0") do
         = text_field_tag :q, params[:q], placeholder: "Suche", name: "q", type: "search", class:"mr-sm-2 input form-control"

--- a/src/app/views/layouts/application.slim
+++ b/src/app/views/layouts/application.slim
@@ -20,7 +20,7 @@ html
               p.alert.alert-danger = alert.html_safe
             = yield
         .col-md-2.d-print-none
-          - if content_for? :sidebar
-            = yield :sidebar
+          - if @order.present? && !controller.is_a?(CheckoutsController)
+            = render "checkouts/sidebar"
     - unless @disable_footer
       = render "layouts/footer"

--- a/src/app/views/sub_categories/show.html.slim
+++ b/src/app/views/sub_categories/show.html.slim
@@ -30,24 +30,6 @@ br
       =< @order.course.name
       | ,
       =< I18n.l(@order.course_at, format: :time_at)
-    - content_for(:sidebar) do
-      .position-fixed style="top: 23%"
-        = link_to("zum Buchungsabschluss", checkout_path, class: "btn btn-secondary d-block #{@order.ordered_experiments.blank? ? "disabled" : ""}".rstrip)
-        = link_to("Buchung abbrechen", checkout_path, method: :delete, class: "btn btn-light mt-2", data: { confirm: "Wollen Sie die Buchung wirklich abbrechen?" })
-        button data-toggle="modal" data-target="#dummy-experiment-modal" class="btn btn-secondary d-block mt-2" manuell Experiment hinzufügen
-      #dummy-experiment-modal.modal.fade tabindex="-1"
-        .modal-dialog
-          .modal-content
-            = simple_form_for(DummyExperiment.new, url: add_experiment_checkout_path, method: :patch) do |f|
-              .modal-header
-                h5.modal-title Manuell Experiment hinzufügen
-                button.close data-dismiss="modal" type="button"
-                  span  &times;
-              .modal-body
-                = f.input :name, label: "Name"
-              .modal-footer
-                button.btn.btn-secondary data-dismiss="modal" type="button" Abbrechen
-                = f.submit "Experiment hinzufügen", class: "btn btn-primary"
   br
 br
 .card

--- a/src/spec/requests/checkout_workflow_spec.rb
+++ b/src/spec/requests/checkout_workflow_spec.rb
@@ -48,6 +48,7 @@ describe "Checkout Workflow" do
       get new_checkout_path
       expect(response).to be_successful
       expect(response.body).to include("Voreinstellungen")
+      expect(response.body).to_not include("Buchung starten")
     end
   end
 
@@ -57,6 +58,7 @@ describe "Checkout Workflow" do
 
       follow_redirect!
       expect(response.body).to include("Buchung erfolgreich gestartet!")
+      expect(response.body).to include("zum Buchungsabschluss")
       order = session[:order]
       expect(order).to_not be_nil
       expect(order.course_at).to eql(Date.tomorrow.midday)
@@ -171,6 +173,7 @@ describe "Checkout Workflow" do
       get(checkout_path)
       expect(response).to be_successful
       expect(response.body).to include("Warenkorb")
+      expect(response.body).to_not include("zum Buchungsabschluss")
     end
   end
 


### PR DESCRIPTION
Zeige Sidebar mit Buttons (zum Buchungsabschluss, Buchung abbrechen und manuell Experiment hinzufügen) auf jeder Seite (außer welche die den Checkout betreffen).

Zeige Button "Buchung starten" nicht an, wenn man auf den Voreinstellungen ist.