### PR TITLE
added future requirements to vision

### DIFF
--- a/Dokumentationen/requirements/vision.adoc
+++ b/Dokumentationen/requirements/vision.adoc
@@ -264,6 +264,6 @@ NOTE: Die unten genannten Anforderungen resultieren aus dem Themenstellermeeting
 
 * das System soll den User informieren, wenn sich an einer bereits gedruckten Dozentenwoche etwas geändert hat 
 * bei der Bearbeitung einer bereits getätigten Buchung soll es möglich werden, auch die Voreinstellungen anzupassen 
-* im Jorunal soll es möglich werden, explizite Buchungen anhand einer Filterfunktion zu finden 
+* im Journal soll es möglich werden, explizite Buchungen anhand einer Filterfunktion zu finden 
 * die Auswertung der Buchungshäufigkeit der Experimente soll anhand der Statistik umgesetzt werden
 * eine Verwaltung der Studiegänge soll (ähnlich wie die der Experimente) ermöglich werden

--- a/Dokumentationen/requirements/vision.adoc
+++ b/Dokumentationen/requirements/vision.adoc
@@ -266,3 +266,4 @@ NOTE: Die unten genannten Anforderungen resultieren aus dem Themenstellermeeting
 * bei der Bearbeitung einer bereits getätigten Buchung soll es möglich werden, auch die Voreinstellungen anzupassen 
 * im Jorunal soll es möglich werden, explizite Buchungen anhand einer Filterfunktion zu finden 
 * die Auswertung der Buchungshäufigkeit der Experimente soll anhand der Statistik umgesetzt werden
+* eine Verwaltung der Studiegänge soll (ähnlich wie die der Experimente) ermöglich werden

--- a/Dokumentationen/requirements/vision.adoc
+++ b/Dokumentationen/requirements/vision.adoc
@@ -257,3 +257,12 @@ a|* Datumsanpassung jeder kopierten Vorlesung ist erforderlich
 * Wochentage ändern sich von Semester zu Semester! (Feiertage etc.) + Unterschiedlicher Fortschritt in den Vorlesungen
 
 |===
+
+==== Finale Zukunftsanforderungen
+
+NOTE: Die unten genannten Anforderungen resultieren aus dem Themenstellermeeting am 10.06.2021 und sind somit endgültig. 
+
+* das System soll den User informieren, wenn sich an einer bereits gedruckten Dozentenwoche etwas geändert hat 
+* bei der Bearbeitung einer bereits getätigten Buchung soll es möglich werden, auch die Voreinstellungen anzupassen 
+* im Jorunal soll es möglich werden, explizite Buchungen anhand einer Filterfunktion zu finden 
+* die Auswertung der Buchungshäufigkeit der Experimente soll anhand der Statistik umgesetzt werden


### PR DESCRIPTION
Ich denke, dass wir diese Zukunftsanforderungen auch auf jeden Fall nochmal irgendwo im Projektbericht erwähnen sollten, um die Gründe (geänderte Priorisierung etc.) deutlich zu machen. Wenn sie nur am Ende der Vision stehen, gehen sie wahrscheinlich unter. 


closes #254